### PR TITLE
Type values into text input and textareas

### DIFF
--- a/lib/akephalos/client.rb
+++ b/lib/akephalos/client.rb
@@ -28,6 +28,7 @@ else
           Filter.new(client)
           client.setAjaxController(HtmlUnit::NicelyResynchronizingAjaxController.new)
           client.setCssErrorHandler(HtmlUnit::SilentCssErrorHandler.new)
+          client.setThrowExceptionOnScriptError(false);
 
           client
         end

--- a/lib/akephalos/node.rb
+++ b/lib/akephalos/node.rb
@@ -55,8 +55,15 @@ module Akephalos
     def value=(value)
       case tag_name
       when "textarea"
-        @_node.setText(value)
+        @_node.setText("")
       when "input"
+        @_node.setValueAttribute("") if @_node.getAttribute("type") != "file"
+      end
+      if @_node.getAttribute("type") != "file"
+        value.each_char do |c|
+          @_node.type(c)
+        end
+      else
         @_node.setValueAttribute(value)
       end
     end


### PR DESCRIPTION
We're relying on keyup and keydown events to be fired when inputs are typed into the input fields.  The default fill_in action for text inputs and textareas do not fire these events.  HtmlUnit has a method to fill in elements a character at a time and fire these events.

It makes sense to be that this should be the default behavior was it mimics the real world browser.
