### PR TITLE
Add #xpath to Akephalos::Node

### DIFF
--- a/lib/akephalos/node.rb
+++ b/lib/akephalos/node.rb
@@ -151,6 +151,11 @@ module Akephalos
       @nodes << nodes
       nodes
     end
+    
+    # @return [String] the XPath expression for this node
+    def xpath
+      @_node.getCanonicalXPath
+    end
   end
 
 end


### PR DESCRIPTION
If you try to call #path on an Akephalos::Capybara::Node (for instance, if you call #inspect, which refers to #path), then Akephalos blows up, because Akephalos::Capybara::Node is calling `native.xpath`, which doesn't work because #xpath isn't defined for an Akephalos::Node. So this patch adds that. Cheers!
