### PR TITLE
Always bind to localhost and avoid DNS lookups. 

### DIFF
--- a/lib/akephalos/remote_client.rb
+++ b/lib/akephalos/remote_client.rb
@@ -30,7 +30,7 @@ module Akephalos
 
       server_port = start!
 
-      DRb.start_service
+      DRb.start_service("druby://127.0.0.1:#{find_available_port}")
       manager = DRbObject.new_with_uri("druby://127.0.0.1:#{server_port}")
 
       # We want to share our local configuration with the remote server


### PR DESCRIPTION
I was receiving similar errors to Issue #63.

```
DRb::DRbConnError: druby://myhostname:17811 - #<Errno::ECONNREFUSED: Connection refused - Connection refused>
```

So I started investigating, and I found that in [63d054](https://github.com/bernerdschaefer/akephalos/commit/63d0541b7f4368ecd754ea087f13c1058008b5c6#L0L25) it was set explicitly to bind to localhost

```
# lib/akephalos/remote_client.rb
- DRb.start_service
+ DRb.start_service("druby://127.0.0.1:#{find_available_port}")
```

but then later [4ed46e](https://github.com/bernerdschaefer/akephalos/commit/4ed46eadaf1299d6a4d6dfe5c442ddd078674562#L2L25) this was removed, without any comments.

```
# lib/akephalos/remote_client.rb
- DRb.start_service("druby://127.0.0.1:#{find_available_port}")
+ DRb.start_service
```

So, this patch just adds back the binding to localhost and avoids DNS lookups.
